### PR TITLE
Fix Images Broken on GitHub Pages

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -37,7 +37,7 @@ jobs:
         # https://github.com/ruby/setup-ruby/releases/tag/v1.207.0
         uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4
         with:
-          ruby-version: '3.2' # Not needed with a .ruby-version file
+          ruby-version: '3.3' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Setup Pages

--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,7 @@ description: >- # this means to ignore newlines until "baseurl:"
   On his website he shares his knowledge and experience regarding SQL Server,
   Postgres, MySQL and more.
 baseurl: "/" # the subpath of your site, e.g. /blog
-url: "https://elijahbelnap.com" # the base hostname & protocol for your site, e.g. http://example.com
+url: "https://elbel13.github.io/elijahbelnap.com" # the base hostname & protocol for your site, e.g. http://example.com
 linkedin_username: elijah-belnap-7788bb123
 github_username:  elbel13
 


### PR DESCRIPTION
The base URL for the website wasn't updated with the GitHub pages URL. Updating it should fix the broken pages.